### PR TITLE
Adding in ability to use `service-check` for Minecraft healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ About once a year or so, my friends and I get an itch to play some Minecraft tog
 
 ## What's in here?
 
+`service-check`: An executable built from my [`service-check` Github Project](https://github.com/jacob-howe/service-check). It is used to broadcast whether or not Minecraft is running over port 7777. You can configure what port this service check runs on by changing line 184 in `userdata.sh`
+
 `eula.txt`: Accepts Mojang's [end user license agreement](https://account.mojang.com/documents/minecraft_eula).
 
 `server.properties`: The properties I've set for my friends' and I's Minecraft server. Check out [this Minecraft Wiki on `server.properties`](https://minecraft.fandom.com/wiki/Server.properties) for more information on what each argument changes.
@@ -32,4 +34,5 @@ Alternatively, if you have an AWS account and want the power to control your Min
 * [`server.properties` Breakdown via Minecraft Wiki](https://minecraft.fandom.com/wiki/Server.properties)
 * [Mojang's End User License Agreement (EULA) for Minecraft](https://account.mojang.com/documents/minecraft_eula)
 * [`discord-ec2-manager` Project by yours truly :)](https://github.com/jacob-howe/discord-ec2-manager)
+* [`service-check` Project by yours truly :)](https://github.com/jacob-howe/service-check)
 * [Amazon Web Services' (AWS) 'Getting Started with EC2' Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html)

--- a/userdata.sh
+++ b/userdata.sh
@@ -18,7 +18,7 @@ fi
 # Change directories into newly created minecraft user's home directory
 cd /home/minecraft
 
-# Pulls in start_minecraft.sh and check_users.sh
+# Pulls in eula & server.properties
 git clone https://github.com/jacob-howe/mc-server.git
 
 # Tests that mc-server was cloned successfully
@@ -91,7 +91,29 @@ ExecStart=/home/minecraft/player_check.sh
 WantedBy=multi-user.target' > /etc/systemd/system/player_check.service
 
 # Setting perms on player_check.service
-sudo chmod 644 /etc/systemd/system/minecraft.service
+sudo chmod 644 /etc/systemd/system/player_check.service
+
+# Creates service for our Service Check
+sudo echo '[Unit]
+Description=Serves status of Minecraft over port 7777
+Wants=network.target
+After=local-fs.target network.target minecraft.service
+
+[Service]
+User=minecraft
+Group=minecraft
+UMask=0027
+
+KillMode=none
+SuccessExitStatus=0 1 255
+
+ExecStart=/home/minecraft/service_check.sh
+
+[Install]
+WantedBy=multi-user.target' > /etc/systemd/system/service_check.service
+
+# Setting perms on service_check.service
+sudo chmod 644 /etc/systemd/system/service_check.service
 
 sudo echo '#!/bin/bash
 
@@ -154,12 +176,19 @@ fi
 logger "Shutting down Server in 1 minute..."
 sudo shutdown' > /home/minecraft/player_check.sh
 
-# Setting perms on player_check.service
-sudo chmod 644 /etc/systemd/system/player_check.service
+sudo echo '#!/bin/bash
+set -e
 
-# Enable both services so that they run on reboot
+cd /home/minecraft
+
+bash -c "./service-check -svc minecraft.service -p 7777"
+' > /home/minecraft/service_check.sh
+
+
+# Enable all services so that they run on reboot
 sudo systemctl enable minecraft
 sudo systemctl enable player_check
+sudo systemctl enable service_check
 
 # Makes shell scripts executable in mc-server/
 chmod a+x /home/minecraft/*.sh
@@ -167,3 +196,4 @@ chmod a+x /home/minecraft/*.sh
 # Start the services
 sudo systemctl start minecraft
 sudo systemctl start player_check
+sudo systemctl start service_check

--- a/userdata.sh
+++ b/userdata.sh
@@ -179,7 +179,8 @@ sudo shutdown' > /home/minecraft/player_check.sh
 sudo echo '#!/bin/bash
 set -e
 
-cd /home/minecraft
+cd /home/minecraft/mc-server
+sudo chmod a+x service-check
 
 bash -c "./service-check -svc minecraft.service -p 7777"
 ' > /home/minecraft/service_check.sh


### PR DESCRIPTION
This PR adds in a healthcheck for `minecraft.service` that defaults to serving over TCP port 7777.  `service-check` is another project of mine and can be found [here](https://github.com/jacob-howe/service-check)